### PR TITLE
Update keyCombo.tsx

### DIFF
--- a/packages/core/src/components/hotkeys/keyCombo.tsx
+++ b/packages/core/src/components/hotkeys/keyCombo.tsx
@@ -27,6 +27,7 @@ export interface IKeyComboProps {
     disabled?: boolean;
     preventDefault?: boolean;
     stopPropagation?: boolean;
+    hideKeyText?: boolean;
 }
 
 export class KeyCombo extends React.Component<IKeyComboProps, {}> {
@@ -40,7 +41,7 @@ export class KeyCombo extends React.Component<IKeyComboProps, {}> {
                 components.push(
                     <kbd className="pt-key pt-modifier-key" key={`key-${i}`}>
                         <span className={`pt-icon-standard ${icon}`} />
-                        {key}
+                        {hideKeyText ? "" : key}
                     </kbd>,
                 );
             } else {


### PR DESCRIPTION
#### Fixes #1980
#### Changes proposed in this pull request:

Adding option to not have the little text next to the special keys. 
![image](https://user-images.githubusercontent.com/2730609/34729074-8f725564-f510-11e7-8c08-08d4cdd591df.png)
If hideKeyText=true then above there would no longer be "shift", just the icon. 
